### PR TITLE
Add event/timer functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
 rust:
+  - stable
+  - beta
   - nightly
 
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/src/base.rs
+++ b/src/base.rs
@@ -65,7 +65,7 @@ impl<'a> ::core::iter::ExactSizeIterator for HandlesIterator<'a> {
 /// Type for EFI_EVENT.
 #[derive(Clone, Copy)]
 #[repr(C)]
-pub struct Event(*mut CVoid);
+pub struct Event(pub *mut CVoid);
 
 /// Type for EFI_STATUS
 #[cfg_attr(target_pointer_width = "32", repr(u32))]

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,7 +1,6 @@
 use core::{default, fmt, ptr, slice};
 
 use void::CVoid;
-use systemtable;
 
 /// Type for EFI_HANDLE.
 #[derive(Copy, Clone, Debug)]

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -2,10 +2,9 @@ use core::ptr;
 use core::mem;
 
 use void::{NotYetDef, CVoid};
-use base::{Event, Handle, Handles, MemoryType, Status, Time};
+use base::{Event, Handle, Handles, MemoryType, Status};
 use guid;
 use table;
-use systemtable;
 
 #[repr(C)]
 pub enum LocateSearchType {

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -84,9 +84,9 @@ impl BootServices {
         Ok(event)
     }
 
-    pub fn set_timer(&self, event: Event, delay_type: TimerDelay, delay_ms: u64) -> Status {
+    pub fn set_timer(&self, event: Event, delay_type: TimerDelay, delay: u64) -> Status {
         unsafe {
-            (self.set_timer)(event, delay_type, delay_ms * 10000)
+            (self.set_timer)(event, delay_type, delay)
         }
     }
 

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -74,7 +74,7 @@ impl BootServices {
     }
 
     pub fn create_event(&self, event_type: EventType, notify_tpl: TPL, notify_func: Option<EventNotify>, notify_context: *const CVoid) -> Result<Event, Status> {
-        let mut event: Event = Event { 0: 0 as *mut CVoid };
+        let mut event: Event = Event(0 as *mut CVoid);
 
         let result = unsafe { (self.create_event)(event_type, notify_tpl, notify_func, notify_context, &mut event) };
         if result != Status::Success {

--- a/src/console.rs
+++ b/src/console.rs
@@ -19,7 +19,6 @@ pub enum ForegroundColor {
     Magenta = 0x5,
     Brown = 0x6,
     LightGray = 0x7,
-    Bright = 0x8,
     DarkGray = 0x8,
     LightBlue = 0x9,
     LightGreen = 0xA,

--- a/src/console.rs
+++ b/src/console.rs
@@ -149,6 +149,10 @@ impl Console {
 
         Status::Success
     }
+
+    pub fn wait_for_key(&self) -> Event {
+        self.input.wait_for_key
+    }
 }
 
 impl SimpleTextOutput for Console {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,21 @@
+use void::CVoid;
+use base::Event;
+
+#[repr(u32)]
+pub enum EventType {
+    Timer = 0x80000000,
+    Runtime = 0x40000000,
+    NotifyWait = 0x00000100,
+    NotifySignal = 0x00000200,
+    SignalExitBootServices = 0x00000201,
+    SignalVirtualAddressChange = 0x60000202
+}
+
+#[repr(C)]
+pub enum TimerDelay {
+    Cancel = 0,
+    Periodic = 1,
+    Relative = 2
+}
+
+pub type EventNotify = extern "win64" fn(event: Event, context: *const CVoid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod systemtable;
 mod bootservices;
 mod runtimeservices;
 mod console;
+mod task;
+mod event;
 
 
 use void::{NotYetDef};
@@ -23,6 +25,10 @@ pub use bootservices::BootServices;
 pub use runtimeservices::{ResetType, RuntimeServices};
 
 pub use console::{Attribute, ForegroundColor, BackgroundColor, InputKey, SimpleTextOutput, SimpleTextInput, Console};
+
+pub use event::*;
+
+pub use task::*;
 
 pub trait Protocol {
     fn guid() -> &'static guid::Guid;

--- a/src/runtimeservices.rs
+++ b/src/runtimeservices.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::fmt;
 
 use void::NotYetDef;
 use base::{Status, Time, TimeCapabilities};

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,7 @@
+#[repr(usize)]
+pub enum TPL {
+    Application = 4,
+    Callback = 8,
+    Notify = 16,
+    HighLevel = 31
+}


### PR DESCRIPTION
Add the `create_event` and `set_timer` functions to boot services, and add a `read_key_timeout` function to `Console` utilizing them.