### PR TITLE
Add functions for manipulating/using DevicePaths

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -153,7 +153,7 @@ fn status_str() {
 }
 
 /// Type for EFI_MEMORY_TYPE
-#[derive(PartialEq, PartialOrd, Debug)]
+#[derive(PartialEq, PartialOrd, Debug, Clone, Copy)]
 #[repr(C)]
 pub enum MemoryType {
     Reserved = 0,

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -5,7 +5,7 @@ use void::{NotYetDef, CVoid};
 use base::{Event, Handle, Handles, MemoryType, Status};
 use event::{EventType, EventNotify, TimerDelay};
 use task::TPL;
-use protocol::{DevicePathProtocol, Protocol};
+use protocol::{DevicePathProtocol, Protocol, get_current_image};
 use guid;
 use table;
 
@@ -68,6 +68,17 @@ pub struct BootServices {
 }
 
 impl BootServices {
+    /// Allocate `size` bytes of memory using type `T`.
+    pub fn allocate_pool<T>(&self, size: usize) -> Result<*mut T, Status> {
+        let mut ptr: *mut u8 = 0 as *mut u8;
+
+        let result = unsafe { (self.allocate_pool)(get_current_image().image_data_type, size, &mut ptr) };
+        if result != Status::Success {
+            return Err(result);
+        }
+        Ok(ptr as *mut T)
+    }
+
     pub fn free_pool<T>(&self, p: *const T) {
         unsafe {
             (self.free_pool)(p as *mut CVoid);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ mod runtimeservices;
 mod console;
 mod task;
 mod event;
+pub mod util;
 
 
 pub use base::{Handle, Handles, Event, MemoryType, Status, Time};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,5 @@ pub use event::*;
 
 pub use task::*;
 
+pub use void::CVoid;
+

--- a/src/protocol/device_path.rs
+++ b/src/protocol/device_path.rs
@@ -42,6 +42,9 @@ pub static EFI_DEVICE_PATH_PROTOCOL_GUID: Guid = Guid(0x09576E91, 0x6D3F, 0x11D2
 /// GUID for UEFI protocol for converting a DevicePath to text
 pub static EFI_DEVICE_PATH_TO_TEXT_PROTOCOL_GUID: Guid = Guid(0x8B843E20, 0x8132, 0x4852, [0x90,0xCC,0x55,0x1A,0x4E,0x4A,0x7F,0x1C]);
 
+/// GUID for UEFI protocol for device path utilities
+pub static EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID: Guid = Guid(0x379BE4E, 0xD706, 0x437D, [0xB0,0x37,0xED,0xB8,0x2F,0xB7,0x72,0xA4]);
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct DevicePathProtocol {
@@ -115,3 +118,42 @@ impl DevicePathToTextProtocol {
     }
 }
 
+#[repr(C)]
+pub struct DevicePathUtilitiesProtocol {
+    get_device_path_size: *const CVoid,
+    duplicate_device_path: *const CVoid,
+    append_device_path: unsafe extern "win64" fn(src1: *const DevicePathProtocol, src2: *const DevicePathProtocol) -> *const DevicePathProtocol,
+    append_device_node: *const CVoid,
+    append_device_path_instance: *const CVoid,
+    get_next_device_path_instance: *const CVoid,
+    is_device_path_multi_instance: *const CVoid,
+    create_device_node: unsafe extern "win64" fn(node_type: u8, node_subtype: u8, node_length: u16) -> *const DevicePathProtocol
+}
+
+impl Protocol for DevicePathUtilitiesProtocol {
+    fn guid() -> &'static Guid {
+        &EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID
+    }
+}
+
+impl DevicePathUtilitiesProtocol {
+    pub fn append_device_path(&self, src1: *const DevicePathProtocol, src2: *const DevicePathProtocol) -> Result<*const DevicePathProtocol, Status> {
+        unsafe {
+            let out = (self.append_device_path)(src1, src2);
+            if out == 0 as *const DevicePathProtocol {
+                return Err(Status::InvalidParameter);
+            }
+            Ok(out)
+        }
+    }
+
+    pub fn create_device_node(&self, node_type: u8, node_subtype: u8, node_length: u16) -> Result<*const DevicePathProtocol, Status> {
+        unsafe {
+            let out = (self.create_device_node)(node_type, node_subtype, node_length);
+            if out == 0 as *const DevicePathProtocol {
+                return Err(Status::InvalidParameter);
+            }
+            Ok(out)
+        }
+    }
+}

--- a/src/protocol/device_path.rs
+++ b/src/protocol/device_path.rs
@@ -14,11 +14,12 @@
 
 use core::mem;
 
+use base::Status;
 use console::SimpleTextOutput;
 use guid::Guid;
 use protocol::Protocol;
 use void::CVoid;
-use util::utf16_ptr_to_str;
+use util::{utf16_ptr_to_str, str_to_utf16_ptr};
 
 #[repr(u8)]
 pub enum DevicePathTypes {
@@ -41,6 +42,9 @@ pub static EFI_DEVICE_PATH_PROTOCOL_GUID: Guid = Guid(0x09576E91, 0x6D3F, 0x11D2
 
 /// GUID for UEFI protocol for converting a DevicePath to text
 pub static EFI_DEVICE_PATH_TO_TEXT_PROTOCOL_GUID: Guid = Guid(0x8B843E20, 0x8132, 0x4852, [0x90,0xCC,0x55,0x1A,0x4E,0x4A,0x7F,0x1C]);
+
+/// GUID for UEFI protocol for converting text to a DevicePath
+pub static EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL_GUID: Guid = Guid(0x5C99A21, 0xC70F, 0x4AD2, [0x8A,0x5F,0x35,0xDF,0x33,0x43,0xF5,0x1E]);
 
 /// GUID for UEFI protocol for device path utilities
 pub static EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID: Guid = Guid(0x379BE4E, 0xD706, 0x437D, [0xB0,0x37,0xED,0xB8,0x2F,0xB7,0x72,0xA4]);
@@ -115,6 +119,30 @@ impl DevicePathToTextProtocol {
         let path = this.device_path_to_text(device_node, display_only, allow_shortcuts);
 
         system_table.console().write(path.unwrap());
+    }
+}
+
+#[repr(C)]
+pub struct DevicePathFromTextProtocol {
+    text_to_device_path_node: unsafe extern "win64" fn(text: *const u16) -> *const DevicePathProtocol,
+    text_to_device_path: unsafe extern "win64" fn(text: *const u16) -> *const DevicePathProtocol,
+}
+
+impl Protocol for DevicePathFromTextProtocol {
+    fn guid() -> &'static Guid {
+        &EFI_DEVICE_PATH_FROM_TEXT_PROTOCOL_GUID
+    }
+}
+
+impl DevicePathFromTextProtocol {
+    pub fn text_to_device_path_node(&self, path: &str) -> Result<&DevicePathProtocol, Status> {
+        str_to_utf16_ptr(path)
+            .map(|utf16_str| unsafe { &*((self.text_to_device_path_node)(utf16_str)) })
+    }
+
+    pub fn text_to_device_path(&self, path: &str) -> Result<&DevicePathProtocol, Status> {
+        str_to_utf16_ptr(path)
+            .map(|utf16_str| unsafe { &*((self.text_to_device_path)(utf16_str)) })
     }
 }
 

--- a/src/protocol/device_path.rs
+++ b/src/protocol/device_path.rs
@@ -48,9 +48,9 @@ pub static EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID: Guid = Guid(0x379BE4E, 0xD70
 #[derive(Debug)]
 #[repr(C)]
 pub struct DevicePathProtocol {
-    type_: u8,
-    sub_type: u8,
-    length: [u8; 2],
+    pub type_: u8,
+    pub sub_type: u8,
+    pub length: [u8; 2],
 }
 
 impl Protocol for DevicePathProtocol {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,4 @@
-use base::{Handle, MemoryType};
+use base::{Handle, MemoryType, Status};
 use guid::Guid;
 use void::NotYetDef;
 
@@ -12,6 +12,8 @@ pub trait Protocol {
 
 /// GUID for UEFI protocol for loaded images
 pub static EFI_LOADED_IMAGE_PROTOCOL_GUID: Guid = Guid(0x5B1B31A1, 0x9562, 0x11d2, [0x8E,0x3F,0x00,0xA0,0xC9,0x69,0x72,0x3B]);
+
+static mut THIS_LOADED_IMAGE: *const LoadedImageProtocol = 0 as *const LoadedImageProtocol;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -27,7 +29,7 @@ pub struct LoadedImageProtocol {
     pub image_base: usize,
     pub image_size: u64,
     image_code_type: MemoryType,
-    image_data_type: MemoryType,
+    pub image_data_type: MemoryType,
 
     //unload: unsafe extern "win64" fn(handle: ::base::Handle),
     unload: *const NotYetDef,
@@ -36,6 +38,25 @@ pub struct LoadedImageProtocol {
 impl Protocol for LoadedImageProtocol {
     fn guid() -> &'static Guid {
         return &EFI_LOADED_IMAGE_PROTOCOL_GUID;
+    }
+}
+
+pub fn set_current_image(handle: Handle) -> Result<&'static LoadedImageProtocol, Status> {
+    let st = ::get_system_table();
+
+    let loaded_image_proto: Result<&'static LoadedImageProtocol, Status> = st.boot_services().handle_protocol(handle);
+    if let Ok(image) = loaded_image_proto {
+        unsafe {
+            THIS_LOADED_IMAGE = image;
+        }
+    }
+
+    loaded_image_proto
+}
+
+pub fn get_current_image() -> &'static LoadedImageProtocol {
+    unsafe {
+        &*THIS_LOADED_IMAGE
     }
 }
 

--- a/src/util/device_path.rs
+++ b/src/util/device_path.rs
@@ -1,0 +1,40 @@
+// Copyright 2017 CoreOS, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use base::Status;
+use protocol::{DevicePathProtocol, DevicePathUtilitiesProtocol};
+use void::CVoid;
+
+pub fn create_file_device_node(filename: &str) -> Result<&DevicePathProtocol, Status> {
+    let node_size_bytes = 4 + (filename.len() + 1) * 2;
+
+    ::get_system_table()
+        .boot_services()
+        .locate_protocol::<DevicePathUtilitiesProtocol>(0 as *const CVoid)
+        .and_then(|utilities| {
+            utilities.create_device_node(4, 4, node_size_bytes as u16)
+                .map(|node_ptr| {
+                    let file_name_ptr: *mut u16 = unsafe { (node_ptr as *const u8).offset(4) as *mut u16 };
+
+                    for i in 0..filename.len() as isize{
+                        unsafe {
+                            *file_name_ptr.offset(i) = *filename.as_ptr().offset(i) as u16;
+                        }
+                    }
+                    unsafe { *file_name_ptr.offset(filename.len() as isize) = 0 };
+
+                    unsafe { &*node_ptr }
+                })
+        })
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+mod device_path;
+pub use self::device_path::*;
+
 use core::slice;
 use core::str;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,68 @@
+// Copyright 2017 CoreOS, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use core::slice;
+use core::str;
+
+use base::Status;
+
+/// Take a null-terminated UTF-16 string (such as one returned by EFI functions) and determine its
+/// length.
+pub fn utf16_strlen(c: *const u16) -> usize {
+    let mut len: usize = 0;
+    
+    unsafe {
+        while *(c.offset(len as isize)) != 0 {
+            len += 1;
+        }
+    }
+
+    len
+}
+
+/// Convert a raw pointer to a UTF-16 string to a rust &str.
+pub fn utf16_ptr_to_str(chars: *const u16) -> Result<&'static str, Status> { 
+    let strlen = utf16_strlen(chars);
+
+    let raw_u8_ptr: Result<*mut u8, Status> = ::get_system_table().boot_services().allocate_pool(strlen);
+    if let Err(status) = raw_u8_ptr {
+        return Err(status);
+    }
+    let raw_u8_ptr = raw_u8_ptr.unwrap();
+
+    for i in 0..strlen as isize {
+        unsafe {
+            *(raw_u8_ptr.offset(i)) = *(chars.offset(i)) as u8;
+        }
+    }
+
+    let u8_slice = unsafe { slice::from_raw_parts(raw_u8_ptr, strlen) };
+    unsafe {
+        Ok(str::from_utf8_unchecked(u8_slice))
+    }
+}
+
+pub fn str_to_utf16_ptr(chars: &str) -> Result<*const u16, Status> {
+    ::get_system_table()
+        .boot_services()
+        .allocate_pool(chars.len() + 1)
+        .map(|u16_ptr| {
+            for i in 0..chars.len() as isize {
+                unsafe {
+                    *(u16_ptr.offset(i)) = *(chars.as_ptr().offset(i));
+                }
+            }
+            unsafe { *(u16_ptr.offset(chars.len() as isize)) = 0 };
+            u16_ptr as *const u16
+        })
+}


### PR DESCRIPTION
Manipulating `DevicePathProtocol` structs in various ways is necessary primarily for loading new images from disk. Also included in this PR is `allocate_pool`, which is needed for allocating memory for some of the string conversion functions.