### PR TITLE
Add DevicePath functions/utilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,5 @@ pub use event::*;
 
 pub use task::*;
 
+pub use void::CVoid;
+

--- a/src/protocol/device_path.rs
+++ b/src/protocol/device_path.rs
@@ -29,10 +29,121 @@ pub enum DevicePathTypes {
     End = 0x7F
 }
 
+impl Into<u8> for DevicePathTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[repr(u8)]
+pub enum HardwareSubTypes {
+    PCI = 0x01,
+    PCCARD = 0x02,
+    MemoryMapped = 0x03,
+    Vendor = 0x04,
+    Controller = 0x05,
+    BMC = 0x06
+}
+
+impl Into<u8> for HardwareSubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[repr(u8)]
+pub enum ACPISubTypes {
+    ACPIDevicePath = 0x01,
+    ExpandedACPIDevicePath = 0x02,
+    _ADR = 0x03
+}
+
+impl Into<u8> for ACPISubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+pub enum MessagingSubTypes {
+    ATAPI = 0x01,
+    SCSI = 0x02,
+    FibreChannel = 0x03,
+    // The EFI specification calls this type "1394", but that won't work as an enum variant for
+    // Rust.
+    FireWire = 0x4,
+    USB = 0x5,
+    I2O = 0x6,
+    Infiniband = 0x9,
+    Vendor = 0xA,
+    MACAddress = 0xB,
+    IPv4 = 0xC,
+    IPv6 = 0xD,
+    UART = 0xE,
+    USBClass = 0xF,
+    USBWWID = 0x10,
+    DeviceLogicalUnit = 0x11,
+    SATA = 0x12,
+    iSCSI = 0x13,
+    Vlan = 0x14,
+    FibreChannelEx = 0x15,
+    SASEx = 0x16,
+    NVMExpressNamespace = 0x17,
+    URI = 0x18,
+    UFS = 0x19,
+    SD = 0x1A,
+    Bluetooth = 0x1B,
+    WiFi = 0x1C,
+    eMMC = 0x1D
+}
+
+impl Into<u8> for MessagingSubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[repr(u8)]
+pub enum MediaSubTypes {
+    HardDrive = 0x1,
+    CDROM = 0x2,
+    Vendor = 0x3,
+    FilePath = 0x4,
+    MediaProtocol = 0x5,
+    PIWGFirmwareFile = 0x6,
+    PIWGFirmwareVolume = 0x7,
+    RelativeOffsetRange = 0x8,
+    RAMDisk = 0x9
+}
+
+impl Into<u8> for MediaSubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
+#[repr(u8)]
+pub enum BIOSSubTypes {
+    BIOSBootSpecification = 0x1
+}
+
+impl Into<u8> for BIOSSubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
+}
+
 #[repr(u8)]
 pub enum EndPathSubTypes {
     EndInstance = 0x01,
     EndEntirePath = 0xFF
+}
+
+impl Into<u8> for EndPathSubTypes {
+    fn into(self) -> u8 {
+        self as u8
+    }
 }
 
 /// GUID for UEFI protocol for device paths

--- a/src/protocol/device_path.rs
+++ b/src/protocol/device_path.rs
@@ -160,9 +160,9 @@ pub static EFI_DEVICE_PATH_UTILITIES_PROTOCOL_GUID: Guid = Guid(0x379BE4E, 0xD70
 #[derive(Debug)]
 #[repr(C)]
 pub struct DevicePathProtocol {
-    type_: u8,
-    sub_type: u8,
-    length: [u8; 2],
+    pub type_: u8,
+    pub sub_type: u8,
+    pub length: [u8; 2],
 }
 
 impl Protocol for DevicePathProtocol {

--- a/src/util/device_path.rs
+++ b/src/util/device_path.rs
@@ -1,0 +1,44 @@
+// Copyright 2017 CoreOS, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use base::Status;
+use protocol::{DevicePathProtocol, DevicePathUtilitiesProtocol, DevicePathTypes, MediaSubTypes};
+use void::CVoid;
+use util::*;
+
+pub fn create_file_device_node(filename: &str) -> Result<&DevicePathProtocol, Status> {
+    str_to_utf16_ptr(filename).and_then(|filename_ptr| {
+        let filename_len = utf16_strlen(filename_ptr);
+        let node_size_bytes = 4 + (filename_len + 1) * 2;
+
+        ::get_system_table()
+            .boot_services()
+            .locate_protocol::<DevicePathUtilitiesProtocol>(0 as *const CVoid)
+            .and_then(|utilities| {
+                utilities.create_device_node(DevicePathTypes::Media, MediaSubTypes::FilePath, node_size_bytes as u16)
+                    .map(|node_ptr| {
+                        let node_filename_ptr: *mut u16 = unsafe { (node_ptr as *const u8).offset(4) as *mut u16 };
+
+                        for i in 0..filename_len as isize{
+                            unsafe {
+                                *node_filename_ptr.offset(i) = *filename_ptr.offset(i);
+                            }
+                        }
+                        unsafe { *node_filename_ptr.offset(filename_len as isize) = 0 };
+
+                        unsafe { &*node_ptr }
+                    })
+            })
+    })
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -11,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+mod device_path;
+pub use self::device_path::*;
+
 use core::slice;
 use core::str;
 


### PR DESCRIPTION
Primary changes:
* `DevicePathUtilities` for manipulating `DevicePathProtocol` structs
* `DevicePathFromText` for parsing strings into `DevicePathProtocol` structs
* `create_file_device_node` for creating `DevicePathProtocol` structs for files