### PR TITLE
util: explicitly cast u16 pointers before access

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -79,10 +79,10 @@ pub fn str_to_utf16_ptr(chars: &str) -> Result<*const u16, Status> {
                 }
 
                 unsafe {
-                    *(u16_ptr.offset(i as isize)) = c as u16;
+                    *((u16_ptr as *mut u16).offset(i as isize)) = c as u16;
                 }
             }
-            unsafe { *(u16_ptr.offset(chars.len() as isize)) = 0 };
+            unsafe { *((u16_ptr as *mut u16).offset(chars.len() as isize)) = 0 };
 
             Ok(u16_ptr as *const u16)
         })


### PR DESCRIPTION
As explained in rust-lang/rust#46906, methods on values which are raw
pointers to unknown types now generate warnings, and will generate hard
errors in the future.